### PR TITLE
Added Arm64 Support in Travis-Ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,19 @@ addons:
       - python3  
       - python3-pip   
 
+matrix:
+    jobs:
+        - arch: amd64
+        - dist: focal
+          sudo: required
+          group: edge
+          arch: arm64-graviton2
+          virt: vm
+
 script:
-  - sudo /snap/bin/lxd.migrate -yes
+  - if [[ "${TRAVIS_CPU_ARCH}" != "arm64" ]]; then
+        sudo /snap/bin/lxd.migrate -yes;
+    fi
   - sudo /snap/bin/lxd waitready
   - sudo /snap/bin/lxd init --auto
   - sudo usermod --append --groups lxd $USER
@@ -30,4 +41,8 @@ script:
   - ./tests/smoke-test.sh
   - export UNDER_TIME_PRESSURE="True"
   - (cd tests; pytest -s verify-branches.py)
-  - (cd tests; sudo -E pytest -s -ra test-addons.py)
+  - if [[ "${TRAVIS_CPU_ARCH}" == "arm64" ]]; then
+        cd tests; travis_wait 20 sudo -E pytest -s -ra test-addons.py;
+    else
+        cd tests; sudo -E pytest -s -ra test-addons.py;
+    fi

--- a/tests/validators.py
+++ b/tests/validators.py
@@ -253,8 +253,12 @@ def validate_registry():
     pvc_yaml = yaml.safe_load(pvc_stdout)
     storage = pvc_yaml['spec']['resources']['requests']['storage']
     assert re.match("(^[2-9][0-9]{1,}|^[1-9][0-9]{2,})(Gi$)", storage)
-    docker("pull busybox")
-    docker("tag busybox localhost:32000/my-busybox")
+    if (os.uname()[4] == 'aarch64'):
+        docker("pull busybox:1.28.2-musl")
+        docker("tag busybox:1.28.2-musl localhost:32000/my-busybox")
+    else:
+        docker("pull busybox")
+        docker("tag busybox localhost:32000/my-busybox")
     docker("push localhost:32000/my-busybox")
 
     here = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
Hi,

Package Owner: Mohneesh Jha
PR change Details:

#Patch Details : .travis.yml and validators.py have been modified :
- .travis.yml : arm64-graviton tag has been added inside the matrix for travis-testing
- validators.py : Added arm64 support for busy-box server deployment in the system

#Testing Detail :
The testing is done over travis

#Reviewer Comment : < To be filled by Reviewer >

#PR Description :
Here is my commit message : Added ARM64 job in Travis-CI

Body of PR : 
- Added ARM64-graviton job in Travis-CI.
- Added arm64 support for running busybox

Signed-off-by: odidev@puresoftware.com.

#Reviewer: Pruthvi Teja and Rajeev Nayan

Thanks,
Mohneesh Jha
